### PR TITLE
Fix various typos and broken syntax

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+title: >-
+  h0neytr4p: Easy to configure Honeypot for Blue Team
+message: 'If you use this software, please cite it as below.'
+type: software
+authors:
+  - given-names: Subhash 
+    family-names: Popuri
+    twitter: https://twitter.com/pbssubhash
+  - given-names: Aakash  
+    family-names: Madaan
+    twitter: https://twitter.com/me_godsky

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Authors: <br>
 - Aakash; [Twitter](https://twitter.com/me_godsky) | [LinkedIn](https://in.linkedin.com/in/aakashmadaan13) <br> 
 
 <br>
+
 ## What is h0neytr4p? 
+
 Honeytrap (a.k.a h0neytr4p) is an easy to configure, deploy honeypot for protecting against web recon and exploiting. 
 
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func PrintBanner() {
        Built by a Red team, with <3     |  $$$$$$/                              | $$      
              h0neytr4p v0.1             \______/                               |__/      
         Built by zer0p1k4chu & g0dsky
-    https://github.com/pbssubhash/h0neyt4p
+    https://github.com/pbssubhash/h0neytr4p
 	`)
 }
 


### PR DESCRIPTION
- The README header on What is h0neytr4p was not rendering correctly. Fixed by adding a space before the header.
- The h0neytr4p repository link in the help has a typo and therefore leads to a 404 GitHub page.
- Add a CITATION.cff file so the tool can get referenced adequately in blogs and other publications.